### PR TITLE
New post and updated venue information for FinagleCon

### DIFF
--- a/source/blog/2015-06-11-announcing-finaglecon.md
+++ b/source/blog/2015-06-11-announcing-finaglecon.md
@@ -5,14 +5,14 @@ published: true
 post_author:
   display_name: Travis Brown
   twitter: travisbrown
-tags: Finagle
+tags: Finagle, FinagleCon
 ---
 
 Yesterday we opened registration and the call for participation for
 [FinagleCon][finaglecon], a new annual conference for the Finagle community.
-This year's conference will be co-located with [Scala by the Bay][sbtb] at the
-[Kaiser Center][kaiser] in Oakland, CA, and will take place on Thursday, August
-13, the day before Scala by the Bay begins.
+This year's conference will be a [Scala by the Bay][sbtb] event hosted
+[at Twitter HQ][venue-change] in San Francisco, and will take place on Thursday,
+August 13, the day before Scala by the Bay begins.
 
 <p align="center">
   <a href="http://scala.bythebay.io/">
@@ -66,3 +66,4 @@ us know—we're on Twitter at [@finaglecon][twitter], and you can also reach us
 [sbtb]: http://scala.bythebay.io/
 [sbtb-tickets]: http://scala.bythebay.io/tickets.html
 [twitter]: https://twitter.com/finaglecon
+[venue-change]: https://finagle.github.io/blog/2015/07/15/new-finaglecon-venue/

--- a/source/blog/2015-07-15-new-finaglecon-venue.md
+++ b/source/blog/2015-07-15-new-finaglecon-venue.md
@@ -1,0 +1,42 @@
+---
+layout: post
+title: New FinagleCon venue
+published: true
+post_author:
+  display_name: Travis Brown
+  twitter: travisbrown
+tags: Finagle, FinagleCon
+---
+
+We're pleased to announce that this year's [FinagleCon][finaglecon] will now be
+hosted at Twitter's new [One 10th Street Expansion][one-tenth] in San Francisco.
+We believe that this location will be more convenient than the Kaiser Center in
+Oakland for many attendees, and we're looking forward to showing off this brand
+new space.
+READMORE
+
+The One 10th Street Expansion is next door to Twitter HQ at 1355 Market Street,
+and is easily accessible from the [Civic Center / UN Plaza BART station](http://www.bart.gov/stations/civc),
+or by any of a number of [Muni bus routes](https://www.sfmta.com/) along Market
+Street.
+
+<iframe width="600" height="450" frameborder="0" style="border:0; padding: 0.5em 0em;" src="https://www.google.com/maps/embed/v1/place?q=875%20Stevenson%20Street%2C%20San%20Francisco%2C%20CA%2094103%2C%20United%20States&key=AIzaSyCvVSiXiD5D0wPQwoqFXTIRckhmD5Zk3ao" allowfullscreen></iframe>
+
+Parking is available at the [Fox Plaza Public Parking Garage][fox-plaza], the [Civic Center
+Garage][civic-center], and several [other locations in the area][parking]. A limited number of public bicycle rack spaces are
+available on Market—please [contact us](mailto:finaglecon@twitter.com) if you'd
+like to arrange for secure bike parking.
+
+Although we're no longer located at the same venue as the other
+[Scala by the Bay](http://scala.bythebay.io/) events, FinagleCon is of course still
+a part of the larger Scala by the Bay conference, and all Scala by the Bay attendees
+receive free registration for FinagleCon.
+
+We'll be getting started with breakfast at 8:30 AM on the morning of August 13
+(stay tuned for the full program announcement tomorrow), and look forward to seeing you there!
+
+[civic-center]: https://www.google.com/maps/place/Civic+Center+Garage/@37.7802614,-122.4179613,17z/data=!3m1!4b1!4m2!3m1!1s0x8085809a2f67bb53:0x6511ff5de0e3c609
+[finaglecon]: https://finagle.github.io/finaglecon/
+[fox-plaza]: https://www.google.com/maps/place/Fox+Plaza+Public+Parking+Garage/@37.7771814,-122.4176978,17z/data=!3m1!4b1!4m2!3m1!1s0x8085809c09d4de63:0xef4edd2f27698fee
+[one-tenth]: https://www.google.com/maps/place/875+Stevenson+St,+San+Francisco,+CA+94103/@37.776292,-122.416245,17z/data=!3m1!4b1!4m2!3m1!1s0x8085809c5b48986f:0xb150a76f58e9f2da
+[parking]: http://en.parkopedia.com/parking/twitter_hq_market_street_san_francisco_ca_united_states/?ac=1&country=US&lat=37.776692&lng=-122.41678200000001


### PR DESCRIPTION
Updates have been [published](https://finagle.github.io/blog/2015/07/15/new-finaglecon-venue/) already—this just adds the source.