### PR TITLE
Blog post for scala 2.10 and java 7

### DIFF
--- a/source/blog/2016-04-20-scala-210-and-java7.md
+++ b/source/blog/2016-04-20-scala-210-and-java7.md
@@ -1,0 +1,38 @@
+---
+layout: post
+title: Final Scala 2.10 and Java 7 releases
+published: true
+post_author:
+  display_name: Kevin Oliver
+  twitter: kevino
+tags: Finagle, Finatra, Util, Scrooge, TwitterServer, Ostrich
+---
+
+The upcoming releases of our family of projects will be the final release for
+Scala 2.10 and Java 7. These should be:
+
+* Finagle 6.35.0
+* Finatra 2.1.6
+* Util 6.34.0
+* Scrooge 4.7.0
+* TwitterServer 1.20.0
+* Ostrich 9.18.0
+
+Java 7 reached its [end-of-life](http://www.oracle.com/technetwork/java/eol-135779.html)
+in April 2015 and we would like to begin using the Java 8 libraries as well as
+remove some Java 7 specific workarounds. Once Scala 2.12 is released, we plan
+to add support for cross-compiling Scala 2.11 and 2.12.
+
+Note that the scrooge-sbt-plugin will continue to be published for only
+Scala 2.10 due to sbt plugin requirements.
+
+If important patch releases become necessary we will try to accomodate these
+needs.
+
+Please let us know if you have any questions, either by
+getting in touch through [@finagle](https://twitter.com/finagle), the
+[Finaglers mailing list](https://groups.google.com/forum/#!forum/finaglers),
+or [chat](https://gitter.im/twitter/finagle). For Finatra get in touch through
+[@finatra](https://twitter.com/finatra), the
+[Finatra mailing list](https://groups.google.com/forum/#!forum/finatra-users),
+or [chat](https://gitter.im/twitter/finatra).


### PR DESCRIPTION
Notify our users of the plan to do a final set of Scala 2.10/Java 7 releases.