### PR TITLE
Add a docker workflow to the site publishing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:18.04 as base-image
+
+RUN apt-get update -qqy \
+  && apt-get install -qqy --no-install-recommends \
+        ssh \
+        build-essential \
+        libxml2-dev \
+        libxslt1-dev \
+        nodejs \
+        gpg \
+        curl \
+        git \
+        ruby-full \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* \
+ && gem update --system \
+ && gem install bundler:1.16.6
+
+

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,5 @@ gem 'rake', '12.3.3'
 gem "rdiscount", '2.2.0.1'
 gem "redcarpet", '3.5.1'
 
+gem "tzinfo-data"
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,8 @@ GEM
       hitimes
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2021.3)
+      tzinfo (>= 1.0.0)
     uber (0.0.15)
     uglifier (2.7.2)
       execjs (>= 0.3.0)
@@ -158,6 +160,7 @@ DEPENDENCIES
   rake (= 12.3.3)
   rdiscount (= 2.2.0.1)
   redcarpet (= 3.5.1)
+  tzinfo-data
 
 BUNDLED WITH
    1.16.6

--- a/README.md
+++ b/README.md
@@ -9,23 +9,40 @@ repository and submit a pull request for us to review.
 
 ## Setup
 
-Once you've forked the repository, run the following command to grab the
-project's dependencies:
+The first thing you need is a recent version of Docker. See the 
+[Docker Desktop](https://www.docker.com/products/docker-desktop) page for installation
+instructions.
+
+The second thing we need to do is get the docker image built. We have a simple helper
+command to do that for you:
 
 ``` bash
-gem install bundler
-bundle install
+$ build_docker_image.sh
 ```
 
-Note that you'll need to have [Ruby](https://www.ruby-lang.org/)
-and [RubyGems](https://rubygems.org/) installed first.
+This will build a new docker image on your local machine and tag it `ghpublish`.
+Once that completes successfully we can boot into our docker image and start our work.
+
+``` bash
+$ docker_start.sh
+   # ... Container starts ...
+docker $ cd finagle.github.io
+docker $ bundle install # installs all the dependencies from the gemfile
+```
+
+Now you're ready to start working on the site.
 
 ## Generating the site
 
-Now you can run `bundle exec rake dev` and open a browser window to `http://localhost:4567/`
-to see your local build of the site. Any changes you make to the `sources`
-directory will be reflected more or less immediately, and errors will be shown
-in the console you launched `rake dev` in.
+Once inside the container with the bundle installed we can generate and preview the site:
+
+``` bash
+docker $ bundle exec middleman server # preview the site locally before publishing
+```
+
+You can open the site preview from the host OS and preview the files by going to 
+`http://localhost:4567/` in your host OS's browser. Updates to the underlying source files
+will be detected and automatically rebuilt for the previewing server.
 
 ## Writing a post
 
@@ -57,9 +74,17 @@ have changes to suggest, etc. Please let us know if you have any questions!
 
 ## Deploying the site
 
+---
+**NOTE**
+
+You must have the appropriate Github access to perform the deployment step.
+
+---
+
 Once you merged you new blog post into the `source` branch, it's time to get that deployed
 on [Github Pages](https://pages.github.com/) by running `bundle exec middleman deploy`
-against the `source` branch.
+against the `source` branch from inside the docker container (if you exited you'll need to
+`bundle install` again).
 
 ## Licensing
 

--- a/build_docker_image.sh
+++ b/build_docker_image.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# This is pretty basic... It just builds the image and tags it as ghpublish
+docker build -t ghpublish .

--- a/docker_start.sh
+++ b/docker_start.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# This script will boot you into the image ready to start at the `bundle install` command.
+docker run -p 4567:4567 -v "$HOME/.gitconfig:/root/.gitconfig" -v "$HOME/.ssh:/root/.ssh" -v "$PWD:/finagle.github.io" -it ghpublish bash


### PR DESCRIPTION
Problem

It's a huge pain to try and maintain a consistent ruby environment on
ones development machine. There is a nonstop struggle to get the right
version of ruby, the gems installed, and everything coherent.

Solution

Use docker to build consistent environments. We add a Dockerfile which
bootstraps a Ubuntu 18.04 image with all the fixins and our entry point
becomes
```
$ bundle install
$ preview_the_site
$ publish_the_site
```